### PR TITLE
User is able to copy templates with one postfix to templates with other postfix within one account

### DIFF
--- a/lib/mandrill_templates_sync/account_templates_duplicator.ex
+++ b/lib/mandrill_templates_sync/account_templates_duplicator.ex
@@ -1,0 +1,24 @@
+defmodule MandrillTemplatesSync.AccountTemplatesDuplicator do
+  def duplicate(key, from, to) do
+    templates_with_postfix(from, key)
+      |> rename_templates(from, to)
+      |> publish(key)
+  end
+
+  defp templates_with_postfix(postfix, key) do
+    TemplatesList.fetch_with_postfix(postfix, key)
+  end
+
+  defp rename_templates(templates, from_postfix, to_postfix) do
+    Enum.map(templates, &(rename_template(&1, from_postfix, to_postfix)))
+  end
+
+  defp rename_template(template, from_postfix, to_postfix) do
+    %{ template | 
+      name: String.replace_suffix(template.name, from_postfix, to_postfix) }
+  end
+
+  defp publish(templates, key) do
+    Publisher.publish(templates, key)
+  end
+end

--- a/lib/mandrill_templates_sync/account_templates_duplicator.ex
+++ b/lib/mandrill_templates_sync/account_templates_duplicator.ex
@@ -1,21 +1,31 @@
 defmodule MandrillTemplatesSync.AccountTemplatesDuplicator do
+  alias MandrillTemplatesSync.TemplatesList
+  alias MandrillTemplatesSync.Publisher
+
   def duplicate(key, from, to) do
-    templates_with_postfix(from, key)
+    templates_for_env(from, key)
       |> rename_templates(from, to)
+      |> amend_label(from, to)
       |> publish(key)
   end
 
-  defp templates_with_postfix(postfix, key) do
-    TemplatesList.fetch_with_postfix(postfix, key)
+  defp templates_for_env(env, key) do
+    TemplatesList.fetch_for_env(env, key)
   end
 
-  defp rename_templates(templates, from_postfix, to_postfix) do
-    Enum.map(templates, &(rename_template(&1, from_postfix, to_postfix)))
+  defp rename_templates(templates, from_env, to_env) do
+    Enum.map(templates, &(rename_template(&1, from_env, to_env)))
   end
 
-  defp rename_template(template, from_postfix, to_postfix) do
+  defp rename_template(template, from_env, to_env) do
     %{ template | 
-      name: String.replace_suffix(template.name, from_postfix, to_postfix) }
+      name: String.replace_suffix(template.name, "[#{from_env}]", "[#{to_env}]") }
+  end
+
+  defp amend_label(templates, from, to) do
+    templates
+      |> Stream.map(fn template -> update_in(template.labels, &List.delete(&1, from)) end)
+      |> Stream.map(fn template -> update_in(template.labels, &([to|&1])) end)
   end
 
   defp publish(templates, key) do

--- a/lib/mandrill_templates_sync/cli.ex
+++ b/lib/mandrill_templates_sync/cli.ex
@@ -15,7 +15,7 @@ defmodule MandrillTemplatesSync.Cli do
     case parse do
       { [help: true], _, _ } -> :help
       { [ source_key: source, destination_key: dest ], _, _ } -> [ source, dest ]
-      { [ account_key: key, from_postfix: from, to_postfix: to ], _, _ } -> [ key, from, to ]
+      { [ account_key: key, from_env: from, to_env: to ], _, _ } -> [ key, from, to ]
       _                      -> :help
     end
   end

--- a/lib/mandrill_templates_sync/cli.ex
+++ b/lib/mandrill_templates_sync/cli.ex
@@ -21,7 +21,17 @@ defmodule MandrillTemplatesSync.Cli do
   end
 
   def process(:help) do
-    IO.puts "Usage: mandrill_templates_sync --source-key=KEY1 --destination-key=KEY2"
+    IO.puts """
+    Usage: mandrill_template_sync --souce-key=<KEY1> --destination_key=<KEY2>
+       or: mandrill_template_sync --account-key=<KEY> --from-env=<ENV1> --to-env=<ENV2>
+
+    Examples:
+      Copy all templates from source to destination account:
+        mandrill_templates_sync --source-key=KEY1 --destination-key=KEY2
+
+      Duplicate templates postfixed by "[staging]" and change postfix to "[production]" within one account:
+        mandrill_templates_sync --account-key=KEY --from-env=staging --to-env=production
+    """
   end
 
   def process([source_key, destination_key]) do

--- a/lib/mandrill_templates_sync/cli.ex
+++ b/lib/mandrill_templates_sync/cli.ex
@@ -1,6 +1,7 @@
 defmodule MandrillTemplatesSync.Cli do
   alias MandrillTemplatesSync.Publisher
   alias MandrillTemplatesSync.TemplatesList
+  alias MandrillTemplatesSync.AccountTemplatesDuplicator
 
   def run(argv) do
     argv
@@ -14,6 +15,7 @@ defmodule MandrillTemplatesSync.Cli do
     case parse do
       { [help: true], _, _ } -> :help
       { [ source_key: source, destination_key: dest ], _, _ } -> [ source, dest ]
+      { [ account_key: key, from_postfix: from, to_postfix: to ], _, _ } -> [ key, from, to ]
       _                      -> :help
     end
   end
@@ -25,5 +27,9 @@ defmodule MandrillTemplatesSync.Cli do
   def process([source_key, destination_key]) do
     TemplatesList.fetch(source_key)
       |> Publisher.publish(destination_key)
+  end
+
+  def process([key, from, to]) do
+    AccountTemplatesDuplicator.duplicate(key, from, to)
   end
 end

--- a/lib/mandrill_templates_sync/publisher.ex
+++ b/lib/mandrill_templates_sync/publisher.ex
@@ -1,11 +1,10 @@
 defmodule MandrillTemplatesSync.Publisher do
-  alias MandrillTemplatesSync.Template
   @api_endpoint "https://mandrillapp.com/api/1.0/"
 
 
   def publish(templates, key) do
     templates
-      |> Enum.each &(publish_template(&1, key))
+      |> Enum.each( &(publish_template(&1, key)) )
   end
 
   defp publish_template(template, key) do
@@ -29,6 +28,7 @@ defmodule MandrillTemplatesSync.Publisher do
       subject: template.publish_subject,
       code: template.publish_code,
       text: template.publish_text,
+      labels: template.labels,
       publish: true
     }
 

--- a/lib/mandrill_templates_sync/template.ex
+++ b/lib/mandrill_templates_sync/template.ex
@@ -1,5 +1,5 @@
 defmodule MandrillTemplatesSync.Template do
-  defstruct [ :name, :publish_code, :publish_subject,
+  defstruct [ :name, :publish_code, :publish_subject, :labels,
               :publish_from_email, :publish_from_name, :publish_text
   ]
 end

--- a/lib/mandrill_templates_sync/templates_list.ex
+++ b/lib/mandrill_templates_sync/templates_list.ex
@@ -6,7 +6,16 @@ defmodule MandrillTemplatesSync.TemplatesList do
   def fetch(key) do
     list_url(key)
       |> HTTPoison.get()
-      |> handle_response
+      |> handle_response()
+  end
+
+  def fetch_with_postfix(postfix, key) do
+    fetch(key)
+      |> select_with_postfix(postfix)
+  end
+
+  defp select_with_postfix(templates, postfix) do
+    Enum.filter(templates, &(String.ends_with?(&1.name, "-#{postfix}")))
   end
 
   defp list_url(key) do

--- a/lib/mandrill_templates_sync/templates_list.ex
+++ b/lib/mandrill_templates_sync/templates_list.ex
@@ -9,13 +9,13 @@ defmodule MandrillTemplatesSync.TemplatesList do
       |> handle_response()
   end
 
-  def fetch_with_postfix(postfix, key) do
+  def fetch_for_env(env, key) do
     fetch(key)
-      |> select_with_postfix(postfix)
+      |> select_for_env(env)
   end
 
-  defp select_with_postfix(templates, postfix) do
-    Enum.filter(templates, &(String.ends_with?(&1.name, "-#{postfix}")))
+  defp select_for_env(templates, env) do
+    Enum.filter(templates, &String.ends_with?(&1.name, "[#{env}]"))
   end
 
   defp list_url(key) do

--- a/test/mandrill_templates_sync_cli_test.exs
+++ b/test/mandrill_templates_sync_cli_test.exs
@@ -25,6 +25,11 @@ defmodule MandrillTemplatesSyncCliTest do
     assert parse_args(["--source-key", "KEY1", "--destination-key", "KEY2"]) == ["KEY1", "KEY2"]
   end
 
+  test "should recognize one account synchronization options" do
+    assert parse_args(["--account-key", "KEY", "--from-postfix", "staging", "--to-postfix", "production"]) 
+      == ["KEY", "staging", "production"]
+  end
+
   test "seeing help message" do
     fun = fn ->
       run([])

--- a/test/mandrill_templates_sync_cli_test.exs
+++ b/test/mandrill_templates_sync_cli_test.exs
@@ -26,7 +26,7 @@ defmodule MandrillTemplatesSyncCliTest do
   end
 
   test "should recognize one account synchronization options" do
-    assert parse_args(["--account-key", "KEY", "--from-postfix", "staging", "--to-postfix", "production"]) 
+    assert parse_args(["--account-key", "KEY", "--from-env", "staging", "--to-env", "production"]) 
       == ["KEY", "staging", "production"]
   end
 


### PR DESCRIPTION
It helps developers to maintain staging and production templates in one mandrill account. Postfix should be separated with dash, i.e. `welcome-staging`.

Use:

```
./mandrill_templates_sync --account-key=KEY --from-postfix=staging --to-postfix=production
```

in order to copy `*-staging` templates to `*-production`.
